### PR TITLE
fix: build package before pdm install to prevent dirty version suffix

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,6 +31,14 @@ jobs:
         python-version: "3.12"
     - name: Install dependencies
       run: pip install -r requirements.txt
+    # Build Distribution Package
+    # IMPORTANT: pdm build must run BEFORE pdm install.
+    # pdm install regenerates pdm.lock (a tracked file), making the working tree dirty.
+    # pdm-backend appends +d<date> to the version when the tree is dirty, which
+    # causes PyPI to reject the upload (local version identifiers are not allowed).
+    - name: Build package
+      run: pdm build
+
     - name: Install package
       run: pdm install
 
@@ -49,10 +57,6 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: kuhl-haus/kuhl-haus-magpie
         fail_ci_if_error: true
-
-    # Build Distribution Package
-    - name: Build package
-      run: pdm build
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## Problem

When the publish workflow ran, `pdm install` was called **before** `pdm build`. `pdm install` regenerates `pdm.lock`, which is a tracked file. This made the working tree dirty at build time.

pdm-backend's SCM versioning appends `+d<date>` to the version when the working tree is dirty:
```python
# pdm/backend/hooks/version/scm.py
dirty_format = "+d{time:%Y%m%d}"  # when distance is None (exact tag) + dirty
```

Result: a tagged commit produced `0.5.3+d20260305` instead of `0.5.3`. PyPI and TestPyPI reject packages with local version identifiers (PEP 440) with a 400 Bad Request.

## Fix

Move `pdm build` to run **before** `pdm install`, so the distribution is built from a clean working tree. The build step only needs the source and `pdm-backend` (installed via pip from requirements.txt) — it doesn't need the full dev venv.

## Verification

- Local build on clean working tree (tagged HEAD): produces `0.5.3` ✓
- Local build with modified `pyproject.toml` (dirty tree): produces `0.5.3+d20260311` ✗ (confirms root cause)

Closes #12 (if opened) — relates to the TestPyPI 400 error on v0.5.3 publish.