### PR TITLE
chore: upgrade GHA actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -21,12 +21,12 @@ jobs:
 
     # Download and install
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Fetch all history for tags
         persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - name: Install dependencies
@@ -46,19 +46,19 @@ jobs:
     - name: Run tests with coverage
       run: pdm run pytest --cov=kuhl_haus.magpie --cov-report=html --cov-report=xml tests -v
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report
         path: htmlcov/
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v5.5.2
       if: startsWith(github.ref, 'refs/tags/')  # only upload on tag pushes
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: kuhl-haus/kuhl-haus-magpie
         fail_ci_if_error: true
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions-${{ steps.set_run_id.outputs.run_id }}
         path: dist/
@@ -74,12 +74,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for tags
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine image tag
         id: determine_tag
@@ -115,14 +115,14 @@ jobs:
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Magpie image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -134,7 +134,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push Magpie beat image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.celery_beat
@@ -146,7 +146,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push Magpie worker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.celery_worker
@@ -158,7 +158,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Build and push Magpie flower image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile.flower
@@ -183,12 +183,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions-${{ needs.build-and-test.outputs.run_id }}
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@v3.2.0
       with:
         inputs: >-
           ./dist/*.tar.gz
@@ -222,7 +222,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions-${{ needs.build-and-test.outputs.run_id }}
         path: dist/
@@ -244,7 +244,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions-${{ needs.build-and-test.outputs.run_id }}
         path: dist/


### PR DESCRIPTION
Resolves #13.

## Changes

Updates all Node.js 20 actions to their latest Node.js 24 compatible versions before the June 2, 2026 forced migration deadline.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v5 | v7 |
| `sigstore/gh-action-sigstore-python` | v3.0.0 | v3.2.0 |
| `codecov/codecov-action` | v5 | v5.5.2 |

`pypa/gh-action-pypi-publish` uses a rolling `release/v1` tag — no change needed.