### PR TITLE
chore: restrict build-docker job to mainline branch and v* tags

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -67,6 +67,7 @@ jobs:
     name: Build Docker Image
     needs: build-and-test
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/mainline' || startsWith(github.ref, 'refs/tags/v')
 
     permissions:
       packages: write  # IMPORTANT: mandatory for publishing packages


### PR DESCRIPTION
Issue #15.

## Change

Adds a single `if` condition to the `build-docker` job:

```yaml
if: github.ref == 'refs/heads/mainline' || startsWith(github.ref, 'refs/tags/v')
```

- ✅ Runs on pushes to `mainline` (squash-merged PRs)
- ✅ Runs on `v*` tag pushes (releases)
- ⏭️ Skipped on feature branch pushes / PRs
- Downstream release jobs (`github-release`, `publish-to-testpypi`, `publish-to-pypi`) are unaffected — they already gate on `startsWith(github.ref, 'refs/tags/')`