### PR TITLE
chore: add AGENTS.md stub referencing CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AGENTS.md
+
+See [CLAUDE.md](CLAUDE.md) for all agent instructions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# AGENTS.md — kuhl-haus-magpie
+# CLAUDE.md — kuhl-haus-magpie
 
 > Instructions for AI agents assisting with code maintenance of this repository.
 


### PR DESCRIPTION
Adds a minimal `AGENTS.md` that redirects to `CLAUDE.md`, which is the canonical source of agent instructions.

Both Claude Code (`CLAUDE.md`) and Codex/other agents (`AGENTS.md`) will find relevant instructions without duplicating content. Single file to maintain.