### PR TITLE
fix: remove dead code from canary_tasks and consolidate setup error handling

### DIFF
--- a/src/kuhl_haus/magpie/canary_tasks/tasks.py
+++ b/src/kuhl_haus/magpie/canary_tasks/tasks.py
@@ -39,14 +39,6 @@ def http_health_check(script_config_name: str = "http_health_check"):
     }
     try:
         endpoints = EndpointModel.objects.filter(health_check=True, ignore=False)
-    except ObjectDoesNotExist:
-        return {
-            "status": "failed",
-            "results": {
-                "message": f"EndpointModel not found in database"
-            }
-        }
-    try:
         carbon_poster: CarbonPoster = CarbonPoster(
             server_ip=script_config.carbon_server_ip,
             pickle_port=script_config.carbon_pickle_port,
@@ -55,14 +47,11 @@ def http_health_check(script_config_name: str = "http_health_check"):
         return {
             "status": "failed",
             "results": {
-                "message": f"Unhandled exception instantiating CarbonPoster: {e}"
+                "message": f"Unhandled exception during task setup: {e}"
             }
         }
     metrics: List[tuple] = []
     for ep in endpoints:
-        if ep.ignore:
-            logger.info(f"Skipping {ep.mnemonic}")
-            continue
         try:
             m: Metrics = Metrics(
                 name=script_config.application_name,
@@ -145,14 +134,6 @@ def tls_check(script_config_name: str = "tls_check"):
     }
     try:
         endpoints = EndpointModel.objects.filter(tls_check=True, ignore=False)
-    except ObjectDoesNotExist:
-        return {
-            "status": "failed",
-            "results": {
-                "message": f"EndpointModel not found in database"
-            }
-        }
-    try:
         carbon_poster: CarbonPoster = CarbonPoster(
             server_ip=script_config.carbon_server_ip,
             pickle_port=script_config.carbon_pickle_port,
@@ -161,14 +142,11 @@ def tls_check(script_config_name: str = "tls_check"):
         return {
             "status": "failed",
             "results": {
-                "message": f"Unhandled exception instantiating CarbonPoster: {e}"
+                "message": f"Unhandled exception during task setup: {e}"
             }
         }
     metrics: List[tuple] = []
     for ep in endpoints:
-        if ep.ignore:
-            logger.info(f"Skipping {ep.mnemonic}")
-            continue
         try:
             m: Metrics = Metrics(
                 name=script_config.application_name,
@@ -251,14 +229,6 @@ def dns_check(script_config_name: str = "dns_check"):
     }
     try:
         endpoints = EndpointModel.objects.filter(dns_check=True, ignore=False, dns_resolver_list__isnull=False)
-    except ObjectDoesNotExist:
-        return {
-            "status": "failed",
-            "results": {
-                "message": f"EndpointModel not found in database"
-            }
-        }
-    try:
         carbon_poster: CarbonPoster = CarbonPoster(
             server_ip=script_config.carbon_server_ip,
             pickle_port=script_config.carbon_pickle_port,
@@ -267,14 +237,11 @@ def dns_check(script_config_name: str = "dns_check"):
         return {
             "status": "failed",
             "results": {
-                "message": f"Unhandled exception instantiating CarbonPoster: {e}"
+                "message": f"Unhandled exception during task setup: {e}"
             }
         }
     metrics: List[tuple] = []
     for ep in endpoints:
-        if ep.ignore:
-            logger.info(f"Skipping {ep.mnemonic}")
-            continue
         try:
             m: Metrics = Metrics(
                 name=script_config.application_name,

--- a/tests/canary_tasks/test_tasks.py
+++ b/tests/canary_tasks/test_tasks.py
@@ -137,7 +137,7 @@ def test_http_health_check_carbon_poster_instantiation_error(script_config_http)
     ):
         result = http_health_check.run("http_health_check")
     assert result["status"] == "failed"
-    assert "CarbonPoster" in result["results"]["message"]
+    assert "task setup" in result["results"]["message"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Surfaced by the #19 depth analysis. Two unreachable code patterns were present in all three task functions (`http_health_check`, `tls_check`, `dns_check`):

**Pattern 1:** `EndpointModel.objects.filter()` wrapped in `except ObjectDoesNotExist`

`QuerySet.filter()` never raises `ObjectDoesNotExist` — only `.get()` does. These blocks could never execute. Fix: move `filter()` into the existing `CarbonPoster` try block so any unexpected DB exception is still caught.

**Pattern 2:** `if ep.ignore: continue` guard inside a loop already filtered with `ignore=False`

The queryset excludes ignored endpoints before the loop, making the guard unreachable. Fix: removed.

Exception message updated from `"instantiating CarbonPoster"` to `"during task setup"` to reflect the broader scope of the combined block.

**Net change:** -37 lines of dead code, +4 lines of consolidated handling. Coverage: 93% (up from 91%), 198 tests passing.

Related: #21