### PR TITLE
test: raise coverage to 99% with correctness assertions (issue #21)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ omit = [
     "*/api.py",
     "*/migrations/*",
     "*/database/tests.py",
+    "*/database/management/commands/bootstrap.py",
 ]
 
 [tool.coverage.paths]

--- a/tests/canary/tasks/test_dns_check.py
+++ b/tests/canary/tasks/test_dns_check.py
@@ -310,3 +310,26 @@ def test_query_dns_empty_resolvers(mock_endpoint, mock_metrics, mock_logger):
     # Assert
     mock_metrics.set_counter.assert_not_called()
     mock_logger.exception.assert_not_called()
+
+
+@patch('kuhl_haus.magpie.canary.tasks.dns_check.dns_query')
+def test_query_dns_single_resolver_coercion(mock_dns_query, mock_resolver_list_1, mock_endpoint, mock_metrics, mock_logger):
+    """Test that a single resolver object (not a list) is coerced to a list at line 17."""
+    # Return a single DnsResolver object (not wrapped in a list) to trigger coercion
+    single_resolver_list = MagicMock(spec=DnsResolverList)
+    single_resolver_list.resolvers = MagicMock()
+    single_resolver_list.resolvers.get = MagicMock(return_value=mock_resolver_list_1)
+
+    mock_response = MagicMock(spec=dns.message.Message)
+    mock_response.flags = 0
+    mock_response.rcode.return_value = dns.rcode.NOERROR
+    mock_response.to_text.return_value = "DNS Response"
+    mock_dns_query.return_value = mock_response
+
+    query_dns(single_resolver_list, mock_endpoint, mock_metrics, mock_logger)
+
+    # The coercion happened; dns_query should have been called with the single resolver
+    mock_dns_query.assert_called_once_with(
+        mock_resolver_list_1.ip_address, mock_endpoint.hostname, "A", use_tcp=False
+    )
+    assert mock_metrics.attributes['rcode'] == 'NOERROR'

--- a/tests/canary_tasks/test_tasks.py
+++ b/tests/canary_tasks/test_tasks.py
@@ -1,6 +1,6 @@
 """Tests for canary_tasks/tasks.py — Celery task wrappers."""
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 
 from kuhl_haus.magpie.endpoints.models import (
     ScriptConfig,
@@ -113,6 +113,7 @@ def test_http_health_check_no_endpoints(script_config_http):
             result = http_health_check.run("http_health_check")
     assert result["status"] == "success"
     assert "No metrics" in result["results"]["message"]
+    mock_cp_class.return_value.post_metrics.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -126,6 +127,7 @@ def test_http_health_check_with_endpoints(script_config_http, basic_endpoint):
     assert result["status"] == "success"
     assert "metadata" in result
     assert result["metadata"]["script_config"]["name"] == "http_health_check"
+    mock_check.assert_called_once_with(ep=basic_endpoint, metrics=ANY, logger=ANY)
 
 
 @pytest.mark.django_db
@@ -155,6 +157,7 @@ def test_http_health_check_skips_ignored_endpoints(script_config_http, db):
             result = http_health_check.run("http_health_check")
     # No endpoints (filter excludes ignore=True)
     assert result["status"] == "success"
+    mock_check.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +193,7 @@ def test_tls_check_with_endpoints(script_config_tls, basic_endpoint):
             result = tls_check.run("tls_check")
     assert result["status"] == "success"
     assert result["metadata"]["script_config"]["name"] == "tls_check"
+    mock_check.assert_called_once_with(ep=basic_endpoint, metrics=ANY, logger=ANY)
 
 
 @pytest.mark.django_db
@@ -236,6 +240,7 @@ def test_dns_check_with_endpoints(script_config_dns, dns_endpoint):
             result = dns_check.run("dns_check")
     assert result["status"] == "success"
     assert result["metadata"]["script_config"]["name"] == "dns_check"
+    mock_check.assert_called_once_with(resolvers=dns_endpoint.dns_resolver_list, ep=dns_endpoint, metrics=ANY, logger=ANY)
 
 
 @pytest.mark.django_db
@@ -278,3 +283,43 @@ def test_dns_check_metrics_exception_propagates(script_config_dns, dns_endpoint)
         with patch("kuhl_haus.magpie.canary_tasks.tasks.query_dns"):
             with pytest.raises(RuntimeError):
                 dns_check.run("dns_check")
+
+
+# ---------------------------------------------------------------------------
+# Per-endpoint exception handler tests (Task 2)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_http_health_check_endpoint_exception_is_caught(script_config_http, basic_endpoint):
+    from kuhl_haus.magpie.canary_tasks.tasks import http_health_check
+    with patch("kuhl_haus.magpie.canary_tasks.tasks.invoke_health_check", side_effect=RuntimeError("boom")):
+        with patch("kuhl_haus.magpie.canary_tasks.tasks.CarbonPoster"):
+            with patch("kuhl_haus.magpie.canary_tasks.tasks.logger") as mock_logger:
+                result = http_health_check.run("http_health_check")
+    assert result["status"] == "success"
+    mock_logger.exception.assert_called_once()
+    assert "test-ep" in mock_logger.exception.call_args.kwargs["msg"]
+
+
+@pytest.mark.django_db
+def test_tls_check_endpoint_exception_is_caught(script_config_tls, basic_endpoint):
+    from kuhl_haus.magpie.canary_tasks.tasks import tls_check
+    with patch("kuhl_haus.magpie.canary_tasks.tasks.invoke_tls_check", side_effect=RuntimeError("boom")):
+        with patch("kuhl_haus.magpie.canary_tasks.tasks.CarbonPoster"):
+            with patch("kuhl_haus.magpie.canary_tasks.tasks.logger") as mock_logger:
+                result = tls_check.run("tls_check")
+    assert result["status"] == "success"
+    mock_logger.exception.assert_called_once()
+    assert "test-ep" in mock_logger.exception.call_args.kwargs["msg"]
+
+
+@pytest.mark.django_db
+def test_dns_check_endpoint_exception_is_caught(script_config_dns, dns_endpoint):
+    from kuhl_haus.magpie.canary_tasks.tasks import dns_check
+    with patch("kuhl_haus.magpie.canary_tasks.tasks.query_dns", side_effect=RuntimeError("boom")):
+        with patch("kuhl_haus.magpie.canary_tasks.tasks.CarbonPoster"):
+            with patch("kuhl_haus.magpie.canary_tasks.tasks.logger") as mock_logger:
+                result = dns_check.run("dns_check")
+    assert result["status"] == "success"
+    mock_logger.exception.assert_called_once()
+    assert "dns-ep" in mock_logger.exception.call_args.kwargs["msg"]

--- a/tests/endpoints/test_api_views.py
+++ b/tests/endpoints/test_api_views.py
@@ -38,7 +38,9 @@ def test_script_config_list_with_data(api_client):
 def test_endpoint_model_list_empty(api_client):
     response = api_client.get("/api/endpoints/")
     assert response.status_code == 200
-    assert response.data == []
+    data = response.json()
+    assert isinstance(data, list)
+    assert data == []
 
 
 @pytest.mark.django_db

--- a/tests/web/test_health.py
+++ b/tests/web/test_health.py
@@ -1,7 +1,9 @@
 """Tests for web/health.py health check endpoints."""
+import importlib
 import json
 
 import pytest
+from unittest.mock import patch
 from django.test import RequestFactory
 
 
@@ -67,3 +69,16 @@ def test_http_health_no_cache(rf):
     response = http_health(request)
     assert "no-cache" in response.get("Cache-Control", "").lower() or \
            response.status_code == 200
+
+
+def test_json_health_version_fallback(rf):
+    import kuhl_haus.magpie.web.health as health_module
+    # Patch at the source so the re-import during reload gets the mock
+    with patch("importlib.metadata.version", side_effect=Exception("not installed")):
+        importlib.reload(health_module)
+        request = rf.get("/healthz")
+        response = health_module.json_health(request)
+    data = json.loads(response.content)
+    assert data["version"] == "Unknown"
+    # Reload again to restore normal state
+    importlib.reload(health_module)

--- a/tests/web/test_settings.py
+++ b/tests/web/test_settings.py
@@ -1,0 +1,66 @@
+"""Tests for web/settings.py conditional configuration blocks."""
+import importlib
+import pytest
+
+
+def test_settings_with_magpie_domain(monkeypatch):
+    """Test that setting MAGPIE_DOMAIN uses it for session/CSRF cookies and SSL header."""
+    monkeypatch.setenv("MAGPIE_DOMAIN", "example.com")
+    import kuhl_haus.magpie.web.settings as settings_module
+    try:
+        importlib.reload(settings_module)
+        assert settings_module.SESSION_COOKIE_DOMAIN == "example.com"
+        assert settings_module.CSRF_COOKIE_DOMAIN == "example.com"
+        assert settings_module.SECURE_PROXY_SSL_HEADER == ("HTTP_X_FORWARDED_PROTO", "https")
+    finally:
+        monkeypatch.delenv("MAGPIE_DOMAIN")
+        importlib.reload(settings_module)
+
+
+def test_settings_disable_https(monkeypatch):
+    """Test that DISABLE_HTTPS=True sets insecure cookie settings."""
+    monkeypatch.setenv("DISABLE_HTTPS", "True")
+    import kuhl_haus.magpie.web.settings as settings_module
+    try:
+        importlib.reload(settings_module)
+        assert settings_module.SESSION_COOKIE_SECURE is False
+        assert settings_module.CSRF_COOKIE_SECURE is False
+        assert settings_module.COOKIE_SAMESITE == "Lax"
+        assert settings_module.SESSION_COOKIE_SAMESITE == "Lax"
+    finally:
+        monkeypatch.delenv("DISABLE_HTTPS")
+        importlib.reload(settings_module)
+
+
+def test_settings_with_magpie_domain_and_disable_https(monkeypatch):
+    """Test MAGPIE_DOMAIN set with DISABLE_HTTPS=True covers the branch that skips SECURE_PROXY_SSL_HEADER."""
+    monkeypatch.setenv("MAGPIE_DOMAIN", "example.com")
+    monkeypatch.setenv("DISABLE_HTTPS", "True")
+    import kuhl_haus.magpie.web.settings as settings_module
+    try:
+        importlib.reload(settings_module)
+        assert settings_module.SESSION_COOKIE_DOMAIN == "example.com"
+        assert settings_module.SESSION_COOKIE_SECURE is False
+    finally:
+        monkeypatch.delenv("MAGPIE_DOMAIN")
+        monkeypatch.delenv("DISABLE_HTTPS")
+        importlib.reload(settings_module)
+
+
+def test_settings_postgres(monkeypatch):
+    """Test that POSTGRES_HOST triggers the PostgreSQL DATABASES config."""
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_DB", "testdb")
+    monkeypatch.setenv("POSTGRES_USER", "testuser")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "testpass")
+    import kuhl_haus.magpie.web.settings as settings_module
+    try:
+        importlib.reload(settings_module)
+        assert settings_module.DATABASES["default"]["ENGINE"] == "django.db.backends.postgresql"
+        assert settings_module.DATABASES["default"]["NAME"] == "testdb"
+    finally:
+        monkeypatch.delenv("POSTGRES_HOST")
+        monkeypatch.delenv("POSTGRES_DB")
+        monkeypatch.delenv("POSTGRES_USER")
+        monkeypatch.delenv("POSTGRES_PASSWORD")
+        importlib.reload(settings_module)


### PR DESCRIPTION
Resolves #21.

## Results

| Metric | Before (#18) | After (#21) |
|--------|-------------|-------------|
| Line coverage | 91% | **99.6%** |
| Branch coverage | 94% | **100%** |
| Tests passing | 198 | **207** |
| Denominator | 806 stmts | 756 stmts (+ bootstrap.py excluded) |

Only 3 lines remain uncovered: `endpoints/admin.py:38–40` (Django admin form init — noted in issue as low-value boilerplate).

## Changes

| Task | Files | What |
|------|-------|------|
| Task 1 | `pyproject.toml` | Add `bootstrap.py` to coverage omit |
| Task 2 | `tests/canary_tasks/test_tasks.py` | Per-endpoint exception handler tests (×3 tasks) |
| Task 3 | `tests/canary_tasks/test_tasks.py` | Correctness upgrades: `assert_called_once_with(ep=...)`, `assert_not_called()` on 5 weak tests |
| Task 4 | `tests/web/test_health.py` | Version fallback test via `importlib.reload` with mocked `version()` |
| Task 5 | `tests/canary/tasks/test_dns_check.py` | Single-resolver coercion test (dns_check.py:17) |
| Task 6 | `tests/web/test_settings.py` (new) | 4 settings tests: MAGPIE_DOMAIN, DISABLE_HTTPS, MAGPIE_DOMAIN+DISABLE_HTTPS, POSTGRES_HOST branches |
| Bonus | `tests/endpoints/test_api_views.py` | Response body structure assertions |