### PR TITLE
Fix: expose dns_resolver_list in EndpointModel API

### DIFF
--- a/src/kuhl_haus/magpie/endpoints/serializers.py
+++ b/src/kuhl_haus/magpie/endpoints/serializers.py
@@ -33,6 +33,13 @@ class DnsResolverListSerializer(serializers.ModelSerializer):
 
 
 class EndpointModelSerializer(serializers.ModelSerializer):
+    dns_resolver_list = serializers.SlugRelatedField(
+        slug_field='name',
+        queryset=DnsResolverList.objects.all(),
+        required=False,
+        allow_null=True,
+    )
+
     class Meta:
         model = EndpointModel
         fields = [
@@ -44,4 +51,5 @@ class EndpointModelSerializer(serializers.ModelSerializer):
             'status_key', 'healthy_status', 'version_key',
             'connect_timeout', 'read_timeout',
             'ignore', 'tls_check', 'dns_check', 'health_check',
+            'dns_resolver_list',
         ]

--- a/tests/endpoints/test_serializers.py
+++ b/tests/endpoints/test_serializers.py
@@ -98,6 +98,48 @@ def test_endpoint_model_serializer_fields():
     assert data["health_check"] is True
     assert data["tls_check"] is True
     assert data["dns_check"] is True
+    assert data["dns_resolver_list"] is None
+
+
+@pytest.mark.django_db
+def test_endpoint_model_serializer_with_dns_resolver_list_expect_slug_in_output():
+    resolver_list = DnsResolverList.objects.create(name="default")
+    endpoint = EndpointModel.objects.create(
+        mnemonic="ep-dns",
+        hostname="example.com",
+        dns_resolver_list=resolver_list,
+    )
+    data = EndpointModelSerializer(endpoint).data
+    assert data["dns_resolver_list"] == "default"
+
+
+@pytest.mark.django_db
+def test_endpoint_model_serializer_with_no_dns_resolver_list_expect_null():
+    endpoint = EndpointModel.objects.create(
+        mnemonic="ep-no-dns",
+        hostname="example.com",
+    )
+    data = EndpointModelSerializer(endpoint).data
+    assert data["dns_resolver_list"] is None
+
+
+@pytest.mark.django_db
+def test_endpoint_model_serializer_with_valid_resolver_list_name_expect_deserializes():
+    DnsResolverList.objects.create(name="default")
+    serializer = EndpointModelSerializer(
+        data={"mnemonic": "ep", "hostname": "h.com", "dns_resolver_list": "default"}
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["dns_resolver_list"].name == "default"
+
+
+@pytest.mark.django_db
+def test_endpoint_model_serializer_with_invalid_resolver_list_name_expect_validation_error():
+    serializer = EndpointModelSerializer(
+        data={"mnemonic": "ep", "hostname": "h.com", "dns_resolver_list": "nonexistent"}
+    )
+    assert not serializer.is_valid()
+    assert "dns_resolver_list" in serializer.errors
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

The `dns_resolver_list` ForeignKey exists on `EndpointModel` but was omitted from `EndpointModelSerializer`, making it impossible to set or read the resolver list assignment via the REST API.

## Change

Added `dns_resolver_list` to `EndpointModelSerializer` using a `SlugRelatedField` with `slug_field='name'`, so the resolver list is referenced by name (e.g. `"default"`) in API requests and responses — consistent with the `DnsResolverList` model's natural identifier.

```json
{
  "mnemonic": "my-endpoint",
  "hostname": "example.kuhl.haus",
  "dns_check": true,
  "dns_resolver_list": "default"
}
```

The field is optional (`required=False`, `allow_null=True`), so existing API consumers are unaffected.

## Testing

All 207 existing tests pass. Four new tests added to `tests/endpoints/test_serializers.py` covering:
- Read path: resolver list name appears in serialized output
- Read path: null when no resolver list assigned
- Write path: valid resolver list name deserializes correctly
- Write path: invalid resolver list name fails validation