### PR TITLE
Chore: bump codecov/codecov-action from v5.5.2 to v7

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -51,7 +51,7 @@ jobs:
         name: coverage-report
         path: htmlcov/
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v5.5.2
+      uses: codecov/codecov-action@v7
       if: startsWith(github.ref, 'refs/tags/')  # only upload on tag pushes
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Bumps `codecov/codecov-action` from `v5.5.2` to `v7`.

**Fixes two issues seen in the v0.5.10 release build:**
- GPG signature verification failure (`gpg: Can't check signature: No public key`) — Codecov's signing key changed; v7 resolves this
- Node 20 deprecation warning from `actions/github-script` bundled inside v5 — v7 is Node 24-native

Aligns with `kuhl-haus-mdp` which already floats on `v5` (will be ahead of us on v7 after this).